### PR TITLE
proto: introduce aeon_internal.proto

### DIFF
--- a/aeon_internal.proto
+++ b/aeon_internal.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+import "aeon_error.proto";
+import "aeon_value.proto";
+
+package aeon;
+
+// Internal API to Aeon - a distributed database based on Tarantool.
+service InternalService {
+  // Get the gRPC server sideservice configuration.
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
+}
+
+// Get the gRPC server sideservice configuration.
+
+// Instance configuration.
+message Config {
+  // Tarantool instance information.
+  message Instance {
+    // Instance name.
+    string name = 1;
+    // Instance replicaset.
+    string replicaset = 2;
+    // Instance group.
+    string group = 3;
+    // Instance URI.
+    Value uri = 4;
+    // Instance roles.
+    repeated string roles = 5;
+  }
+  // Name of the associated Tarantool instance.
+  string name = 1;
+  // The configuration of "aeon.grpc" role of the associated Tarantool instance.
+  Value params = 2;
+  // Information about all instances from Tarantool configuration.
+  repeated Instance instances = 3;
+}
+
+message GetConfigRequest {}
+
+message GetConfigResponse {
+  // Error information. Set only on failure.
+  Error error = 1;
+  // The gRPC server sideservice configuration.
+  Config config = 2;
+}


### PR DESCRIPTION
This patch adds `aeon_internal.proto` which will be used to implement the internal RPC. Currently this module only adds one RPC which is GetConfig(). This RPC returns the sideservice configuration.

Needed for https://github.com/tarantool/aeon/issues/313